### PR TITLE
Fix a link markup for "Vault on Cloud Run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Cloud Run is on [Stackshare](https://stackshare.io/google-cloud-run) and [StackO
 * 📰 [Secret Manager: Improve Cloud Run security without changing the code](https://medium.com/google-cloud/secret-manager-improve-cloud-run-security-without-changing-the-code-634f60c541e6)
 * 📰 [Cloud Run with static outgoing IP](https://ahmet.im/blog/cloud-run-static-ip/)
 * 📦 [Vault on Cloud Run (using Terraform)](https://github.com/mbrancato/terraform-google-vault)
-* 📦 [Vault on Cloud Run] https://github.com/kelseyhightower/serverless-vault-with-cloud-run
+* 📦 [Vault on Cloud Run](https://github.com/kelseyhightower/serverless-vault-with-cloud-run)
 
 ### Storing Data
 


### PR DESCRIPTION
Hello 🙂  

I noticed one link in the Security section has a broken markup. 

<img width="716" alt="Screen Shot 2021-12-11 at 2 33 23" src="https://user-images.githubusercontent.com/1425259/145617021-b3581886-7daf-497d-9002-ff1e0eac31ce.png">

This PR just fixes that.

By the way, thank you for compiling this awesome list! I'm learning Google Cloud actively and these resources are so fun and help me a lot. 🥰