### PR TITLE
Add Komos regulated ops task router sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Cloud Run is on [Stackshare](https://stackshare.io/google-cloud-run) and [StackO
 * 📦 [django-demo-app-unicodex](https://github.com/GoogleCloudPlatform/django-demo-app-unicodex): Django in Cloud Run with Cloud SQL and Cloud Storages.
 * 📦 [ytdl](https://github.com/ahmetb/ytdl): Serverless video downloader
 * 📦 [microurl](https://github.com/thomasgassmann/microurl): Url shortener and code snippet sharing tool
+* 📦 [Komos regulated ops task router](https://github.com/xuanli/komos-regulated-ops-playbooks/tree/main/examples/google-cloud-run-task-router): Queue browser automation task runs for regulated operations from Cloud Run.
 * 📦 [tweethingz](https://github.com/mchmarny/tweethingz): Twitter follower histogramc
 * 📦 [datastore-cleaner](https://github.com/steren/datastore-cleaner): Automatically clean up old Google Cloud Datastore entities.
 * 📦 [Domain redirector](https://github.com/ahmetb/serverless-url-redirect)


### PR DESCRIPTION
Adds a small Cloud Run sample that queues browser automation task runs for regulated operations. The linked repo includes a Node.js HTTP service, Dockerfile, and deploy command for Cloud Run.